### PR TITLE
Include playername and playerstate in metadata string representation

### DIFF
--- a/ac2/controller.py
+++ b/ac2/controller.py
@@ -104,7 +104,7 @@ class AudioController():
 
     def metadata_notify(self, metadata):
         if metadata.is_unknown() and metadata.playerState == "playing":
-            logging.error("Got empty metadata - what's wrong here? %s",
+            logging.warning("Metadata without artist, album or title - what's wrong here? %s",
                           metadata)
 
         for md in self.metadata_displays:

--- a/ac2/metadata.py
+++ b/ac2/metadata.py
@@ -209,8 +209,9 @@ class Metadata:
         return "{}/{}".format(self.artist, self.title)
     
     def __str__(self):
-        return "{}: {} ({}) {}".format(self.artist, self.title,
-                                       self.albumTitle, self.artUrl)
+        return "[{}, {}] {}: {} ({}) {}".format(self.playerName, self.playerState,
+                                                self.artist, self.title,
+                                                self.albumTitle, self.artUrl)
 
 
 def enrich_metadata(metadata, callback=None):


### PR DESCRIPTION
This PR includes the player name and player state in the metadata string representation, as these are important fields, and help developers reading this information from log files. The "empty metadata" error has been improved to make it clear what's missing and that this is a warning, not a critical problem.