### PR TITLE
Metadata plugin volume notifications

### DIFF
--- a/ac2/alsavolume.py
+++ b/ac2/alsavolume.py
@@ -23,19 +23,18 @@ SOFTWARE.
 import threading
 import time
 import logging
-
+import alsaaudio
 
 class ALSAVolume(threading.Thread):
 
     def __init__(self, mixer_name):
-        import alsaaudio
 
         super().__init__()
 
         self.listeners = []
         self.volume = -1
         self.unmuted_volume = 0
-        self.pollinterval = 0.3
+        self.pollinterval = 0.2
         if self.pollinterval < 0.1:
             self.pollinterval = 0.1
 
@@ -48,8 +47,6 @@ class ALSAVolume(threading.Thread):
             self.mixer_name = None
 
     def set_volume(self, vol):
-        import alsaaudio
-
         # Check if this was a "mute" operation and store unmuted volume
         if vol == 0 and self.volume != 0:
             self.unmuted_volume = self.volume
@@ -102,8 +99,6 @@ class ALSAVolume(threading.Thread):
                                   e, listener)
 
     def current_volume(self):
-        import alsaaudio
-
         volumes = alsaaudio.Mixer(self.mixer_name).getvolume()
         channels = 0
         vol = 0

--- a/ac2/plugins/metadata/console.py
+++ b/ac2/plugins/metadata/console.py
@@ -32,5 +32,8 @@ class MetadataConsole(MetadataDisplay):
     def notify(self, metadata):
         print("{:16s}: {}".format(metadata.playerName, metadata))
 
+    def update_volume(self, volume):
+        print(f"Volume changed to {volume}%")
+
     def __str__(self):
         return "console"

--- a/ac2/plugins/metadata/http_post.py
+++ b/ac2/plugins/metadata/http_post.py
@@ -93,8 +93,9 @@ class MetadataHTTPRequest(MetadataDisplay):
             logging.error("got HTTP error %s when posting metadata to %s",
                           r.status_code,
                           self.url)
-            
-        
+
+    def update_volume(self, volume):
+        pass
 
     def __str__(self):
         return "http"

--- a/ac2/plugins/metadata/lametric.py
+++ b/ac2/plugins/metadata/lametric.py
@@ -89,7 +89,8 @@ class LaMetricPush(MetadataDisplay):
 
             post_data(url, json.dumps(data), headers=headers, verify=False)
         
-
+    def update_volume(self, volume):
+        pass
 
 class LaMetricDiscovery(Thread):
     

--- a/ac2/plugins/metadata/lastfm.py
+++ b/ac2/plugins/metadata/lastfm.py
@@ -152,6 +152,8 @@ class LastFMScrobbler(MetadataDisplay):
         else:
             logging.info("no track data, not scrobbling %s", lastsong_md)
             
+    def update_volume(self, volume):
+        pass
 
     def __str__(self):
         return "lastfmscrobbler@{}".format(self.networkname)

--- a/ac2/plugins/metadata/postgresql.py
+++ b/ac2/plugins/metadata/postgresql.py
@@ -90,6 +90,9 @@ class MetadataPostgres(MetadataDisplay):
         self.currentmetadata = metadata
         self.starttimestamp = datetime.now()
 
+    def update_volume(self, volume):
+        pass
+
     def write_metadata(self, songdict):
         try:
             if songdict is None:

--- a/audiocontrol2.py
+++ b/audiocontrol2.py
@@ -238,15 +238,14 @@ def parse_config(debugmode=False):
                 logging.error("Exception during controller %s initialization",
                               classname)
                 logging.exception(e)
-                
-    #  Additional metadata modules
-    for section in config.sections():
+
         if section.startswith("metadata:"):
             [_,classname] = section.split(":",1)
             try:
                 params = config[section]
-                mddisplay = create_object(classname, params)
-                mpris.register_metadata_display(mddisplay)
+                metadata_display = create_object(classname, params)
+                mpris.register_metadata_display(metadata_display)
+                volume_control.add_listener(metadata_display)
                 logging.info("registered metadata display %s", controller)
                 report_activate("audiocontrol_metadata_"+classname)
             except Exception as e:


### PR DESCRIPTION
This PR adds metadata plugins as a listener for volume level changes. This adds the possibility to show the volume level on a display when changing it. 

The same plugin instance is used on purpose, as volume and metadata usually are shown on the same screen, or pushed to the same device, or pushed to the same webpage, ... . A separate plugin definition for volume and metadata changes would mean plugin writers must use a singleton instance, which might cause code duplication across plugins (but it is possible).

The poll frequency is increased a bit to be able to display the changes more smoothly. This should not come at a higher cpu cost, as a global import for the audio package should make the module more efficient. 

Things to discuss are mostly naming in my opinion, although I might have missed existing ways to do this, or might not be seeing possible future issues with this approach. Feel free to discuss or propose alternatives and improvements, or reject if this is already possible.
