### PR TITLE
Fixed typo

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -64,7 +64,7 @@ or set the volume using HTTP POST.
 When setting the volume, use JSON encoding with the volume defined as "percent":
 
 ```
-curl -X POST -H "Content-Type: application/json" -d '{"percent":"50"} http://127.0.0.1:80/api/volume
+curl -X POST -H "Content-Type: application/json" -d '{"percent":"50"}' http://127.0.0.1:80/api/volume
 ```
 
 If the percent value starts with + or -, it will change the volume by this amount (e.g. "+1" will by


### PR DESCRIPTION
Example `curl` contained a missing '