### PR TITLE
Consistent naming for notify methods, fix deprecated method calls

### DIFF
--- a/ac2/alsavolume.py
+++ b/ac2/alsavolume.py
@@ -78,24 +78,24 @@ class ALSAVolume(threading.Thread):
 
     def run(self):
         while True:
-            self.update_volume()
+            self.notify_listeners()
             time.sleep(self.pollinterval)
 
-    def update_volume(self, always_notify=False):
-        vol = self.current_volume()
+    def notify_listeners(self, always_notify=False):
+        current_vol = self.current_volume()
 
         # Check if this was a "mute" operation and store unmuted volume
-        if vol == 0 and self.volume != 0:
+        if current_vol == 0 and self.volume != 0:
             self.unmuted_volume = self.volume
 
-        if always_notify or (vol != self.volume):
-            logging.debug("ALSA volume changed to {}".format(vol))
-            self.volume = vol
+        if always_notify or (current_vol != self.volume):
+            logging.debug("ALSA volume changed to {}".format(current_vol))
+            self.volume = current_vol
             for listener in self.listeners:
                 try:
-                    listener.update_volume(vol)
+                    listener.notify_volume(current_vol)
                 except Exception as e:
-                    logging.debug("exception %s during %s.volume_changed_percent",
+                    logging.debug("exception %s during %s.notify_volume",
                                   e, listener)
 
     def current_volume(self):

--- a/ac2/controller.py
+++ b/ac2/controller.py
@@ -112,7 +112,7 @@ class AudioController():
                 logging.debug("metadata_notify: %s %s", md, metadata)
                 md.notify_async(copy.copy(metadata))
             except Exception as e:
-                logging.warn("could not notify %s: %s", md, e)
+                logging.warning("could not notify %s: %s", md, e)
                 logging.exception(e)
 
         self.metadata = metadata
@@ -224,7 +224,7 @@ class AudioController():
         logging.debug("received metadata update: %s", updates)
 
         if self.metadata is None:
-            logging.warn("ooops, got an update, but don't have metadata")
+            logging.warning("ooops, got an update, but don't have metadata")
             return
 
         if self.metadata.songId() != songId:

--- a/ac2/data/coverartarchive.py
+++ b/ac2/data/coverartarchive.py
@@ -41,7 +41,7 @@ def coverartarchive_cover(mbid):
         return url
 
     except Exception as e:
-        logging.warn("can't load cover for %s: %s", mbid, e)
+        logging.warning("can't load cover for %s: %s", mbid, e)
 
 
 def coverdata(mbid):

--- a/ac2/data/guess.py
+++ b/ac2/data/guess.py
@@ -48,7 +48,7 @@ def guess_stream_order(stream, field1, field2, use_cloud=True):
         caching_supported = True
     else:
         caching_supported = False
-        logging.warn("not a web radio stream, won't use caching")
+        logging.warning("not a web radio stream, won't use caching")
     
     stats = stream_stats.get(stream,{"ta": 0, "at": 0, "order": ORDER_UNKNOWN, "cloud": ORDER_UNKNOWN})
     

--- a/ac2/data/hifiberry.py
+++ b/ac2/data/hifiberry.py
@@ -60,7 +60,7 @@ def hifiberry_cover(song_mbid, album_mbid, artist_mbid, player="unknown"):
             return (None, 0, 0)
             
     except Exception as e:
-        logging.warn("can't load cover for %s: %s", song_mbid, e)
+        logging.warning("can't load cover for %s: %s", song_mbid, e)
         logging.exception(e)
         return (None, 0, 0)
     

--- a/ac2/metadata.py
+++ b/ac2/metadata.py
@@ -229,21 +229,21 @@ def enrich_metadata(metadata, callback=None):
         try:
             musicbrainz.enrich_metadata(metadata)
         except Exception as e:
-            logging.warn("error when retrieving data from musicbrainz")
+            logging.warning("error when retrieving data from musicbrainz")
             logging.exception(e)
             
         # Then HiFiBerry MusicDB
         try:
             hifiberrydb.enrich_metadata(metadata)
         except Exception as e:
-            logging.warn("error when retrieving data from hifiberry db")
+            logging.warning("error when retrieving data from hifiberry db")
             logging.exception(e)
 
         # Then Last.FM
         try:
             lastfmdata.enrich_metadata(metadata)
         except Exception as e:
-            logging.warn("error when retrieving data from last.fm")
+            logging.warning("error when retrieving data from last.fm")
             logging.exception(e)
                 
         # try Fanart.TV, but without artist picture

--- a/ac2/players/mpris.py
+++ b/ac2/players/mpris.py
@@ -67,7 +67,7 @@ class MPRIS():
                                     "PlaybackStatus")
             return state
         except Exception as e:
-            logging.warn("got exception %s while polling MPRIS data", e)
+            logging.warning("got exception %s while polling MPRIS data", e)
             
             
     
@@ -88,7 +88,7 @@ class MPRIS():
                 if supported:
                     supported_commands.append(command)
         except Exception as e:
-            logging.warn("got exception %s", e)
+            logging.warning("got exception %s", e)
 
         return supported_commands
     

--- a/ac2/players/vollibrespot.py
+++ b/ac2/players/vollibrespot.py
@@ -197,7 +197,7 @@ class VollibspotifyMetadataListener(threading.Thread):
                 logging.info("got access_token update")
                 self.control.access_token = data["token"]
             else:
-                logging.warn("don't know how to handle %s",data)
+                logging.warning("don't know how to handle %s",data)
                 
         except Exception as e:
             logging.error("error while parsing %s (%s)", message,e)

--- a/ac2/plugins/metadata/console.py
+++ b/ac2/plugins/metadata/console.py
@@ -32,7 +32,7 @@ class MetadataConsole(MetadataDisplay):
     def notify(self, metadata):
         print("{:16s}: {}".format(metadata.playerName, metadata))
 
-    def update_volume(self, volume):
+    def notify_volume(self, volume):
         print(f"Volume changed to {volume}%")
 
     def __str__(self):

--- a/ac2/plugins/metadata/http_post.py
+++ b/ac2/plugins/metadata/http_post.py
@@ -94,7 +94,7 @@ class MetadataHTTPRequest(MetadataDisplay):
                           r.status_code,
                           self.url)
 
-    def update_volume(self, volume):
+    def notify_volume(self, volume):
         pass
 
     def __str__(self):

--- a/ac2/plugins/metadata/lametric.py
+++ b/ac2/plugins/metadata/lametric.py
@@ -89,7 +89,7 @@ class LaMetricPush(MetadataDisplay):
 
             post_data(url, json.dumps(data), headers=headers, verify=False)
         
-    def update_volume(self, volume):
+    def notify_volume(self, volume):
         pass
 
 class LaMetricDiscovery(Thread):

--- a/ac2/plugins/metadata/lastfm.py
+++ b/ac2/plugins/metadata/lastfm.py
@@ -152,7 +152,7 @@ class LastFMScrobbler(MetadataDisplay):
         else:
             logging.info("no track data, not scrobbling %s", lastsong_md)
             
-    def update_volume(self, volume):
+    def notify_volume(self, volume):
         pass
 
     def __str__(self):

--- a/ac2/plugins/metadata/postgresql.py
+++ b/ac2/plugins/metadata/postgresql.py
@@ -90,7 +90,7 @@ class MetadataPostgres(MetadataDisplay):
         self.currentmetadata = metadata
         self.starttimestamp = datetime.now()
 
-    def update_volume(self, volume):
+    def notify_volume(self, volume):
         pass
 
     def write_metadata(self, songdict):
@@ -118,7 +118,7 @@ class MetadataPostgres(MetadataDisplay):
             cur.close()
 
         except Exception as e:
-            logging.warn("can't write to database: %s", e)
+            logging.warning("can't write to database: %s", e)
             self.conn = None
 
     def db_connection(self):
@@ -133,10 +133,10 @@ class MetadataPostgres(MetadataDisplay):
                                              password=self.password,
                                              host=self.host)
             else:
-                logging.warn("username and/or password missing for db connection")
+                logging.warning("username and/or password missing for db connection")
 
         except Exception as e:
-            logging.warn("can't connect to postgresql: %s", e)
+            logging.warning("can't connect to postgresql: %s", e)
             self.conn = None
 
         return self.conn

--- a/ac2/plugins/volume/http.py
+++ b/ac2/plugins/volume/http.py
@@ -35,7 +35,7 @@ class VolumeHTTPRequest():
         self.url = url
         pass
 
-    def update_volume(self, volume_percent):
+    def notify_volume(self, volume_percent):
 
         if (self.request_type == "json"):
             try:

--- a/ac2/webserver.py
+++ b/ac2/webserver.py
@@ -324,7 +324,7 @@ class AudioControlWebserver(MetadataDisplay):
                 metadata.artUrl = "artwork/" + key
                 self.artwork[key]=localfile
             else:
-                logging.warn("artwork file %s does not exist, removing artUrl (%s)",
+                logging.warning("artwork file %s does not exist, removing artUrl (%s)",
                              localfile,
                              metadata.artUrl)
                 metadata.artUrl=None
@@ -339,7 +339,7 @@ class AudioControlWebserver(MetadataDisplay):
         self.metadata = metadata
                
 
-    def update_volume(self, vol):
+    def notify_volume(self, vol):
         self.volume = vol
 
     def send_metadata_update(self, updates, song_id = None):
@@ -350,7 +350,7 @@ class AudioControlWebserver(MetadataDisplay):
                 logging.debug("sending update %s to %s", u, updates)
                 u.update_metadata_attributes(updates, song_id)
             except Exception as e:
-                logging.warn("couldn't send update to %s: %s", u, e)
+                logging.warning("couldn't send update to %s: %s", u, e)
 
     # ##
     # ## end metadata functions
@@ -438,7 +438,7 @@ class AudioControlWebserver(MetadataDisplay):
                 lover.love(love)
             except Exception as e:
                 ok = False
-                logging.warn("Could not love/unlove via %s: %s", lover, e)
+                logging.warning("Could not love/unlove via %s: %s", lover, e)
 
         if ok:
             self.send_metadata_update({"loved": love})

--- a/audiocontrol2.py
+++ b/audiocontrol2.py
@@ -247,7 +247,7 @@ def parse_config(debugmode=False):
                 metadata_display = create_object(classname, params)
                 mpris.register_metadata_display(metadata_display)
                 volume_control.add_listener(metadata_display)
-                logging.info("registered metadata display %s", controller)
+                logging.info("registered metadata display %s", metadata_display)
                 report_activate("audiocontrol_metadata_"+classname)
             except Exception as e:
                 logging.error("Exception during controller %s initialization",


### PR DESCRIPTION
This PR contains minor improvements, so that audiocontrol2...

- ... uses notify_volume instead of update_volume for a clear and non-ambiguous method name, which matches the existing notify method for metadata.

- ... uses logging.warning instead of the deprecated logging.warn everywhere 

- ... logs metadata display initialization correctly