### PR TITLE
handle play pause event

### DIFF
--- a/ac2/players/vollibrespot.py
+++ b/ac2/players/vollibrespot.py
@@ -162,6 +162,8 @@ class VollibspotifyMetadataListener(threading.Thread):
                 self.control.set_state(STATE_PAUSED)
             elif message=="kSpSinkInactive":
                 self.control.set_state(STATE_PAUSED)
+            elif message == 'kSpDeviceInactive':
+                self.control.set_state(STATE_STOPPED)
             elif message in ["kSpSinkActive","kSpPlaybackActive"]: 
                 self.control.set_state(STATE_PLAYING)
             elif message[0]=='{':
@@ -196,6 +198,13 @@ class VollibspotifyMetadataListener(threading.Thread):
             elif "token" in data:
                 logging.info("got access_token update")
                 self.control.access_token = data["token"]
+            elif 'state' in data:
+                state = data['state'].get('status')
+                logging.info("got a state change")
+                if state == 'pause':
+                    self.control.set_state(STATE_PAUSED)
+                elif state == 'play':
+                    self.control.set_state(STATE_PLAYING)
             else:
                 logging.warn("don't know how to handle %s",data)
                 


### PR DESCRIPTION
It can happen that the connected spotify player pause or play the
current track. This event is reported by vollibrespot but it is not read
nor processed. This link this trigger to a state change.