### PR TITLE
Adding mute functionality to Keyboard controller and API

### DIFF
--- a/ac2/alsavolume.py
+++ b/ac2/alsavolume.py
@@ -76,6 +76,13 @@ class ALSAVolume(threading.Thread):
             if self.unmuted_volume > 0:
                 self.set_volume(self.unmuted_volume)
 
+    def toggle_mute(self):
+        if self.volume != 0:
+            self.unmuted_volume = self.volume
+            self.set_volume(0)
+        elif self.unmuted_volume > 0:
+            self.set_volume(self.unmuted_volume)
+
     def run(self):
         while True:
             self.notify_listeners()

--- a/ac2/alsavolume.py
+++ b/ac2/alsavolume.py
@@ -73,7 +73,7 @@ class ALSAVolume(threading.Thread):
                 self.set_volume(0)
         else:
             logging.debug("unmuting")
-            if self.unmuted_volume > 0:
+            if self.volume == 0 and self.unmuted_volume > 0:
                 self.set_volume(self.unmuted_volume)
 
     def toggle_mute(self):

--- a/ac2/plugins/control/keyboard.py
+++ b/ac2/plugins/control/keyboard.py
@@ -57,7 +57,7 @@ class Keyboard(Controller):
         else:
             self.codetable = {}
             for i in params:
-                self.codetable[int(params[i])] = i
+                self.codetable[int(i)] = params[i]
 
     def handle_key_event(self, event):
         command = self.codetable.get(event.code)

--- a/ac2/plugins/control/keyboard.py
+++ b/ac2/plugins/control/keyboard.py
@@ -39,7 +39,7 @@ class Keyboard(Controller):
             self.codetable = {
                 # volume up
                 115: "volume_up",
-                 # volume down
+                # volume down
                 114: "volume_down",
                 # mute
                 113: "mute",

--- a/ac2/plugins/control/keyboard.py
+++ b/ac2/plugins/control/keyboard.py
@@ -41,6 +41,8 @@ class Keyboard(Controller):
                 115: "volume_up",
                  # volume down
                 114: "volume_down",
+                # mute
+                113: "mute",
                 # right
                 106: "next",
                 # left
@@ -72,6 +74,14 @@ class Keyboard(Controller):
             elif command == "volume_down":
                 if self.volumecontrol is not None:
                     self.volumecontrol.change_volume_percent(-5)
+                    command_run =True
+                else:
+                    logging.info("ignoring %s, no volume control",
+                                    command)
+
+            elif command == "mute":
+                if self.volumecontrol is not None:
+                    self.volumecontrol.toggle_mute()
                     command_run =True
                 else:
                     logging.info("ignoring %s, no volume control",

--- a/ac2/webserver.py
+++ b/ac2/webserver.py
@@ -143,6 +143,9 @@ class AudioControlWebserver(MetadataDisplay):
         self.bottle.route('/api/volume',
                           method="POST",
                           callback=self.volume_post_handler)
+        self.bottle.route('/api/volume/<command>',
+                          method="POST",
+                          callback=self.volume_mute_handler)
         self.bottle.route('/api/system/info',
                           method="GET",
                           callback=self.system_info_handler)
@@ -304,6 +307,25 @@ class AudioControlWebserver(MetadataDisplay):
             response.status = 401
             return "percent value missing"
 
+        return ({"percent":self.volume_control.current_volume()})
+
+    def volume_mute_handler(self, command):
+
+        if self.volume_control is None:
+            response.status = 501
+            return "no volume control available"
+
+        if command == "mute":
+            self.volume_control.set_mute(True)
+        elif command == "unmute":
+            self.volume_control.set_mute(False)
+        elif command == "togglemute":
+            self.volume_control.toggle_mute()
+        else:
+            response.status = 501
+            return "Unknown command {}".format(command)
+
+        response.status = 200
         return ({"percent":self.volume_control.current_volume()})
 
     def status_handler(self):

--- a/doc/api.md
+++ b/doc/api.md
@@ -70,6 +70,18 @@ curl -X POST -H "Content-Type: application/json" -d '{"percent":"50"}' http://12
 If the percent value starts with + or -, it will change the volume by this amount (e.g. "+1" will by
 [one louder](https://www.youtube.com/watch?v=_sRhuh8Aphc))
 
+To mute/unmute the volume or toggle the mute state use POST requests to
+ 
+```
+/api/volume/mute
+/api/volume/unmute
+/api/volume/togglemute
+```
+
+```
+curl -X POST http://127.0.0.1:80/api/volume/togglemute
+```
+
 ## System
 ```
 /api/system/poweroff


### PR DESCRIPTION
This is not a clean "one feature" pull request. 
The main purpose was to implement toggle mute functionality for my usb volume knob control, but then I lost focus and added mute functionality to the REST API also... ;)

Furthermore, I found one bug and one semi bug;
When i tried to override the key mappings for the keyboard controller I noticed that my usb volume controller stopped working, I isolated it to be a bug in the Keyboard constructor when reading the settings params.

The semi bug was in ALSAVolume and the method set_mute(self, mute), it unmuted even if the sound wasn't muted. If the saved  unmuted_volume differed from the current volume then the volume changed to unmuted_volume.

If you want I can do separate pull requests. Or if you reject parts of the PR, I (or you) can remove those parts. 