### PR TITLE
Disable interpolation for configparser

### DIFF
--- a/audiocontrol2.py
+++ b/audiocontrol2.py
@@ -101,7 +101,7 @@ def create_object(classname, param=None):
 def parse_config(debugmode=False):
     server = None
 
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.optionxform = lambda option: option
 
     config.read("/etc/audiocontrol2.conf")


### PR DESCRIPTION
Interpolation allows to replace values with this %(syntax). Audiocontrol2 does not make use of this feature. However since some secrets like the LastFM password are stored as-is in the config file, the parser will crash when the secret contains the '%(' substring. Disabling interpolation returns the secret as-is without trying to interpolate it, allowing the use of such secrets.