### PR TITLE
fix: add DSP volume backend so /api/volume works for optical input (#43)

### DIFF
--- a/ac2/audiocontrol2.py
+++ b/ac2/audiocontrol2.py
@@ -43,6 +43,7 @@ import ac2.data.lastfm as lastfmdata
 
 from ac2.plugins.metadata.lastfm import LastFMScrobbler
 from ac2.alsavolume import ALSAVolume
+from ac2.dspvolume import DSPVolume
 from ac2.metadata import Metadata
 import ac2.metadata
 from ac2.data.mpd import MpdMetadataProcessor
@@ -210,15 +211,36 @@ def parse_config(debugmode=False):
                          player, services)
 
     # Volume
+    # Two backends are supported:
+    #   control=alsa (default): ALSA software mixer. Works for streams that
+    #     flow through ALSA (AirPlay, Spotify, MPD, etc).
+    #   control=dsp: writes the HiFiBerry DSP volume register via
+    #     sigmatcpserver. Required for sources that bypass ALSA, e.g. the
+    #     optical input on DAC+ DSP and Beocreate cards (issue #43).
     volume_control = None
     if "volume" in config.sections():
-        mixer_name = config.get("volume",
-                                "mixer_control",
-                                fallback=None)
-        if mixer_name is not None:
-            volume_control = ALSAVolume(mixer_name)
-            logging.info("monitoring mixer %s", mixer_name)
+        control_type = config.get("volume",
+                                  "control",
+                                  fallback="alsa").strip().lower()
 
+        if control_type == "dsp":
+            dsp_host = config.get("volume", "dsp_host", fallback="localhost")
+            dsp_port = config.getint("volume", "dsp_port", fallback=13141)
+            dbrange = config.getint("volume", "dbrange", fallback=60)
+            volume_control = DSPVolume(host=dsp_host,
+                                       port=dsp_port,
+                                       dbrange=dbrange)
+            logging.info("using DSP volume control at %s:%s",
+                         dsp_host, dsp_port)
+        else:
+            mixer_name = config.get("volume",
+                                    "mixer_control",
+                                    fallback=None)
+            if mixer_name is not None:
+                volume_control = ALSAVolume(mixer_name)
+                logging.info("monitoring mixer %s", mixer_name)
+
+        if volume_control is not None:
             if server is not None:
                 volume_control.add_listener(server)
                 server.set_volume_control(volume_control)

--- a/ac2/audiocontrol2.py
+++ b/ac2/audiocontrol2.py
@@ -225,13 +225,23 @@ def parse_config(debugmode=False):
 
         if control_type == "dsp":
             dsp_host = config.get("volume", "dsp_host", fallback="localhost")
-            dsp_port = config.getint("volume", "dsp_port", fallback=13141)
+            # SigmaTCP (8086) is the default because it's always available on
+            # stock HiFiBerryOS. REST (13141) only works when sigmatcpserver
+            # is started with --enable-rest. Users can force one or the other
+            # via transport=sigmatcp|rest|auto.
+            dsp_port = config.getint("volume", "dsp_port", fallback=8086)
+            rest_port = config.getint("volume", "dsp_rest_port",
+                                      fallback=13141)
+            transport = config.get("volume", "transport",
+                                   fallback="auto").strip().lower()
             dbrange = config.getint("volume", "dbrange", fallback=60)
             volume_control = DSPVolume(host=dsp_host,
                                        port=dsp_port,
+                                       rest_port=rest_port,
+                                       transport=transport,
                                        dbrange=dbrange)
-            logging.info("using DSP volume control at %s:%s",
-                         dsp_host, dsp_port)
+            logging.info("using DSP volume control at %s (transport=%s)",
+                         dsp_host, transport)
         else:
             mixer_name = config.get("volume",
                                     "mixer_control",

--- a/ac2/dspvolume.py
+++ b/ac2/dspvolume.py
@@ -1,0 +1,239 @@
+'''
+Copyright (c) 2024 Modul 9/HiFiBerry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+'''
+
+import threading
+import time
+import math
+import logging
+
+import requests
+
+# Why this module exists:
+# On HiFiBerry DAC+ DSP / Beocreate and similar DSP cards, audio coming from the
+# optical (S/PDIF) input is processed by the DSP hardware and never flows through
+# the ALSA software mixer. That means alsaaudio.Mixer("Master").setvolume() has
+# no effect on optical playback — the GUI slider moves but nothing audible
+# changes (see https://github.com/hifiberry/audiocontrol2/issues/43).
+#
+# DSPVolume writes directly to the DSP's volumeControlRegister via the
+# sigmatcpserver REST API (port 13141 by default). This affects every source
+# that passes through the DSP, including optical.
+
+
+# dB-range that maps 0–100% to the log volume curve. 60 dB matches dsptoolkit's
+# default and keeps the perceived response comparable to other HiFiBerry tools.
+DEFAULT_DBRANGE = 60
+
+# Log coefficients for a 60 dB range, copied from hifiberrydsp.filtering.volume
+# so this module stays free of the hifiberrydsp package dependency.
+_LOG_COEFFS = {
+    50: (0.0031623, 5.757),
+    60: (0.001, 6.908),
+    70: (0.00031623, 8.059),
+    80: (0.0001, 9.210),
+    90: (0.000031623, 10.36),
+    100: (0.00001, 11.51),
+}
+
+
+def _log_coefficients(dbrange):
+    for upper, coeffs in sorted(_LOG_COEFFS.items()):
+        if dbrange <= upper:
+            return coeffs
+    return _LOG_COEFFS[100]
+
+
+def percent_to_amplification(percent, dbrange=DEFAULT_DBRANGE):
+    # Map 0–100 % to a linear amplification factor on a log curve so that
+    # perceived loudness changes roughly evenly across the slider.
+    if percent <= 0:
+        return 0.0
+    if percent >= 100:
+        return 1.0
+    (a, b) = _log_coefficients(dbrange)
+    return a * math.exp(b * float(percent) / 100.0)
+
+
+def amplification_to_percent(amplification, dbrange=DEFAULT_DBRANGE):
+    if amplification <= 0:
+        return 0
+    if amplification >= 1:
+        return 100
+    (a, b) = _log_coefficients(dbrange)
+    return round((math.log(amplification / a) / b) * 100)
+
+
+class DSPVolume(threading.Thread):
+    """Volume controller that writes to the HiFiBerry DSP volume register.
+
+    Exposes the same interface as ALSAVolume so it can be used as a drop-in
+    replacement in audiocontrol2.py. Requires sigmatcpserver to be running
+    with --enable-rest (default on current HiFiBerryOS images)."""
+
+    def __init__(self, host="localhost", port=13141, dbrange=DEFAULT_DBRANGE,
+                 poll_interval=0.5, timeout=2.0):
+        super().__init__()
+
+        self.listeners = []
+        self.volume = -1
+        self.unmuted_volume = 0
+        self.pollinterval = max(0.1, poll_interval)
+        self.dbrange = dbrange
+        self.timeout = timeout
+        self.base_url = "http://{}:{}".format(host, port)
+        # Cached register address resolved from /metadata on first use.
+        self.register_addr = None
+
+        # Resolve the register address once at startup so later set_volume()
+        # calls don't have to hit /metadata every time.
+        try:
+            self.register_addr = self._resolve_register()
+            if self.register_addr is None:
+                logging.error(
+                    "DSPVolume: volumeControlRegister not found in DSP "
+                    "metadata (is a DSP profile loaded?)")
+        except Exception as e:
+            logging.error("DSPVolume: failed to resolve volume register: %s", e)
+
+    # -- HTTP helpers ---------------------------------------------------------
+
+    def _resolve_register(self):
+        url = "{}/metadata".format(self.base_url)
+        r = requests.get(url, timeout=self.timeout)
+        r.raise_for_status()
+        meta = r.json()
+        reg = meta.get("volumeControlRegister")
+        if reg is None:
+            return None
+        return self._parse_int(reg)
+
+    @staticmethod
+    def _parse_int(value):
+        # Metadata values can be plain decimals, hex ("0x1234") or the
+        # dsptoolkit-style "1234/5" (address/length). We only need the address.
+        if isinstance(value, int):
+            return value
+        text = str(value).strip().split("/")[0]
+        if text.lower().startswith("0x"):
+            return int(text, 16)
+        return int(text)
+
+    def _read_register(self):
+        if self.register_addr is None:
+            return None
+        url = "{}/memory/{}?format=float".format(self.base_url,
+                                                 self.register_addr)
+        r = requests.get(url, timeout=self.timeout)
+        r.raise_for_status()
+        values = r.json().get("values", [])
+        if not values:
+            return None
+        return float(values[0])
+
+    def _write_register(self, amplification):
+        if self.register_addr is None:
+            return False
+        url = "{}/memory".format(self.base_url)
+        payload = {"address": self.register_addr, "value": [amplification]}
+        r = requests.post(url, json=payload, timeout=self.timeout)
+        r.raise_for_status()
+        return True
+
+    # -- Public interface (matches ALSAVolume) --------------------------------
+
+    def set_volume(self, vol):
+        # Track the last non-zero volume so unmute can restore it later.
+        if vol == 0 and self.volume != 0:
+            self.unmuted_volume = self.volume
+
+        if vol == self.volume:
+            return
+
+        amp = percent_to_amplification(vol, self.dbrange)
+        try:
+            self._write_register(amp)
+        except Exception as e:
+            logging.error("DSPVolume: failed to set volume to %s%%: %s",
+                          vol, e)
+
+    def change_volume_percent(self, change):
+        vol = self.current_volume()
+        newvol = vol + change
+        if newvol < 0:
+            newvol = 0
+        elif newvol > 100:
+            newvol = 100
+
+        self.set_volume(newvol)
+
+    def set_mute(self, mute):
+        if mute:
+            logging.debug("DSPVolume: muting")
+            if self.volume != 0:
+                self.unmuted_volume = self.volume
+                self.set_volume(0)
+        else:
+            logging.debug("DSPVolume: unmuting")
+            if self.volume == 0 and self.unmuted_volume > 0:
+                self.set_volume(self.unmuted_volume)
+
+    def toggle_mute(self):
+        if self.volume != 0:
+            self.unmuted_volume = self.volume
+            self.set_volume(0)
+        elif self.unmuted_volume > 0:
+            self.set_volume(self.unmuted_volume)
+
+    def run(self):
+        while True:
+            self.notify_listeners()
+            time.sleep(self.pollinterval)
+
+    def notify_listeners(self, always_notify=False):
+        current_vol = self.current_volume()
+
+        if current_vol == 0 and self.volume != 0:
+            self.unmuted_volume = self.volume
+
+        if always_notify or (current_vol != self.volume):
+            logging.debug("DSP volume changed to %s%%", current_vol)
+            self.volume = current_vol
+            for listener in self.listeners:
+                try:
+                    listener.notify_volume(current_vol)
+                except Exception as e:
+                    logging.debug("exception %s during %s.notify_volume",
+                                  e, listener)
+
+    def current_volume(self):
+        try:
+            amp = self._read_register()
+        except Exception as e:
+            logging.debug("DSPVolume: read failed: %s", e)
+            return self.volume if self.volume >= 0 else 0
+
+        if amp is None:
+            return self.volume if self.volume >= 0 else 0
+        return amplification_to_percent(amp, self.dbrange)
+
+    def add_listener(self, listener):
+        self.listeners.append(listener)

--- a/ac2/dspvolume.py
+++ b/ac2/dspvolume.py
@@ -28,23 +28,32 @@ import logging
 import requests
 
 # Why this module exists:
-# On HiFiBerry DAC+ DSP / Beocreate and similar DSP cards, audio coming from the
-# optical (S/PDIF) input is processed by the DSP hardware and never flows through
-# the ALSA software mixer. That means alsaaudio.Mixer("Master").setvolume() has
-# no effect on optical playback — the GUI slider moves but nothing audible
-# changes (see https://github.com/hifiberry/audiocontrol2/issues/43).
+# On HiFiBerry DAC+ DSP / Beocreate and similar DSP cards, audio coming from
+# the optical (S/PDIF) input is processed by the DSP hardware and never flows
+# through the ALSA software mixer. That means alsaaudio.Mixer("Master"|"Softvol")
+# .setvolume() has no effect on optical playback - the GUI slider moves but
+# nothing audible changes (see issue #43).
 #
-# DSPVolume writes directly to the DSP's volumeControlRegister via the
-# sigmatcpserver REST API (port 13141 by default). This affects every source
-# that passes through the DSP, including optical.
+# DSPVolume writes directly to the DSP's volumeControlRegister via
+# sigmatcpserver. That register sits inside the DSP signal path, so it
+# affects every source, including optical.
+#
+# Two transports are supported:
+#   1. SigmaTCP (port 8086, the stock HiFiBerryOS setup) via the
+#      hifiberrydsp.client.sigmatcp.SigmaTCPClient that ships with the OS.
+#      This is tried first because it works on every HiFiBerryOS install
+#      without any sigmatcpserver reconfiguration.
+#   2. REST (port 13141) as a fallback when hifiberrydsp isn't importable
+#      but sigmatcpserver was started with --enable-rest.
+#
+# You can force a specific transport via the `transport` config option
+# (values: "auto", "sigmatcp", "rest").
 
 
-# dB-range that maps 0–100% to the log volume curve. 60 dB matches dsptoolkit's
-# default and keeps the perceived response comparable to other HiFiBerry tools.
 DEFAULT_DBRANGE = 60
 
-# Log coefficients for a 60 dB range, copied from hifiberrydsp.filtering.volume
-# so this module stays free of the hifiberrydsp package dependency.
+# Log coefficients, copied from hifiberrydsp.filtering.volume so the REST
+# path stays free of the hifiberrydsp package dependency.
 _LOG_COEFFS = {
     50: (0.0031623, 5.757),
     60: (0.001, 6.908),
@@ -63,8 +72,6 @@ def _log_coefficients(dbrange):
 
 
 def percent_to_amplification(percent, dbrange=DEFAULT_DBRANGE):
-    # Map 0–100 % to a linear amplification factor on a log curve so that
-    # perceived loudness changes roughly evenly across the slider.
     if percent <= 0:
         return 0.0
     if percent >= 100:
@@ -82,15 +89,135 @@ def amplification_to_percent(amplification, dbrange=DEFAULT_DBRANGE):
     return round((math.log(amplification / a) / b) * 100)
 
 
+# -- Transports --------------------------------------------------------------
+
+
+class _SigmaTCPTransport:
+    """Talks to sigmatcpserver on TCP port 8086 via the client shipped with
+    HiFiBerryOS. Works out of the box on every stock HiFiBerryOS install."""
+
+    def __init__(self, host="127.0.0.1", port=8086):
+        # Import lazily so the REST fallback still works when hifiberrydsp
+        # isn't installed.
+        from hifiberrydsp.client.sigmatcp import SigmaTCPClient
+        from hifiberrydsp.hardware.adau145x import Adau145x
+
+        self._client = SigmaTCPClient(Adau145x, host, port=port)
+        self._register = None
+
+    def resolve_register(self):
+        # request_metadata can return "1234" or "1234/5" (address/length).
+        raw = self._client.request_metadata("volumeControlRegister")
+        if raw is None or raw == "":
+            return None
+        addr = str(raw).strip().split("/")[0]
+        self._register = int(addr, 0)  # 0 -> auto-detect hex/dec
+        return self._register
+
+    def read(self):
+        if self._register is None:
+            return None
+        return self._client.read_decimal(self._register)
+
+    def write(self, amplification):
+        if self._register is None:
+            return False
+        self._client.write_decimal(self._register, amplification)
+        return True
+
+    def describe(self):
+        return "SigmaTCP reg=0x{:x}".format(self._register or 0)
+
+
+class _RestTransport:
+    """Talks to sigmatcpserver's REST API (port 13141 by default). Requires
+    sigmatcpserver to be running with --enable-rest."""
+
+    def __init__(self, host="localhost", port=13141, timeout=2.0):
+        self._base = "http://{}:{}".format(host, port)
+        self._timeout = timeout
+        self._register = None
+
+    def resolve_register(self):
+        r = requests.get("{}/metadata".format(self._base),
+                         timeout=self._timeout)
+        r.raise_for_status()
+        meta = r.json()
+        raw = meta.get("volumeControlRegister")
+        if raw is None:
+            return None
+        addr = str(raw).strip().split("/")[0]
+        self._register = int(addr, 0)
+        return self._register
+
+    def read(self):
+        if self._register is None:
+            return None
+        url = "{}/memory/{}?format=float".format(self._base, self._register)
+        r = requests.get(url, timeout=self._timeout)
+        r.raise_for_status()
+        values = r.json().get("values", [])
+        return float(values[0]) if values else None
+
+    def write(self, amplification):
+        if self._register is None:
+            return False
+        payload = {"address": self._register, "value": [amplification]}
+        r = requests.post("{}/memory".format(self._base),
+                          json=payload, timeout=self._timeout)
+        r.raise_for_status()
+        return True
+
+    def describe(self):
+        return "REST reg=0x{:x}".format(self._register or 0)
+
+
+def _pick_transport(mode, host, port, rest_port):
+    """Return a transport instance with the register already resolved, or
+    None if no transport could be established."""
+    attempts = []
+    if mode in ("auto", "sigmatcp"):
+        attempts.append(("sigmatcp",
+                         lambda: _SigmaTCPTransport(host=host, port=port)))
+    if mode in ("auto", "rest"):
+        attempts.append(("rest",
+                         lambda: _RestTransport(host=host, port=rest_port)))
+
+    for name, factory in attempts:
+        try:
+            t = factory()
+            reg = t.resolve_register()
+            if reg is None:
+                logging.warning(
+                    "DSPVolume: %s transport reached the DSP but "
+                    "volumeControlRegister metadata is missing (profile "
+                    "without volume control?)", name)
+                continue
+            logging.info("DSPVolume: using %s", t.describe())
+            return t
+        except ImportError as e:
+            logging.debug("DSPVolume: %s transport unavailable: %s", name, e)
+        except Exception as e:
+            logging.warning("DSPVolume: %s transport failed: %s", name, e)
+    return None
+
+
+# -- Public class ------------------------------------------------------------
+
+
 class DSPVolume(threading.Thread):
     """Volume controller that writes to the HiFiBerry DSP volume register.
 
     Exposes the same interface as ALSAVolume so it can be used as a drop-in
-    replacement in audiocontrol2.py. Requires sigmatcpserver to be running
-    with --enable-rest (default on current HiFiBerryOS images)."""
+    replacement in audiocontrol2.py."""
 
-    def __init__(self, host="localhost", port=13141, dbrange=DEFAULT_DBRANGE,
-                 poll_interval=0.5, timeout=2.0):
+    def __init__(self,
+                 host="localhost",
+                 port=8086,
+                 rest_port=13141,
+                 transport="auto",
+                 dbrange=DEFAULT_DBRANGE,
+                 poll_interval=0.5):
         super().__init__()
 
         self.listeners = []
@@ -98,79 +225,35 @@ class DSPVolume(threading.Thread):
         self.unmuted_volume = 0
         self.pollinterval = max(0.1, poll_interval)
         self.dbrange = dbrange
-        self.timeout = timeout
-        self.base_url = "http://{}:{}".format(host, port)
-        # Cached register address resolved from /metadata on first use.
-        self.register_addr = None
 
-        # Resolve the register address once at startup so later set_volume()
-        # calls don't have to hit /metadata every time.
-        try:
-            self.register_addr = self._resolve_register()
-            if self.register_addr is None:
-                logging.error(
-                    "DSPVolume: volumeControlRegister not found in DSP "
-                    "metadata (is a DSP profile loaded?)")
-        except Exception as e:
-            logging.error("DSPVolume: failed to resolve volume register: %s", e)
-
-    # -- HTTP helpers ---------------------------------------------------------
-
-    def _resolve_register(self):
-        url = "{}/metadata".format(self.base_url)
-        r = requests.get(url, timeout=self.timeout)
-        r.raise_for_status()
-        meta = r.json()
-        reg = meta.get("volumeControlRegister")
-        if reg is None:
-            return None
-        return self._parse_int(reg)
-
-    @staticmethod
-    def _parse_int(value):
-        # Metadata values can be plain decimals, hex ("0x1234") or the
-        # dsptoolkit-style "1234/5" (address/length). We only need the address.
-        if isinstance(value, int):
-            return value
-        text = str(value).strip().split("/")[0]
-        if text.lower().startswith("0x"):
-            return int(text, 16)
-        return int(text)
-
-    def _read_register(self):
-        if self.register_addr is None:
-            return None
-        url = "{}/memory/{}?format=float".format(self.base_url,
-                                                 self.register_addr)
-        r = requests.get(url, timeout=self.timeout)
-        r.raise_for_status()
-        values = r.json().get("values", [])
-        if not values:
-            return None
-        return float(values[0])
-
-    def _write_register(self, amplification):
-        if self.register_addr is None:
-            return False
-        url = "{}/memory".format(self.base_url)
-        payload = {"address": self.register_addr, "value": [amplification]}
-        r = requests.post(url, json=payload, timeout=self.timeout)
-        r.raise_for_status()
-        return True
+        self._transport = _pick_transport(
+            mode=transport,
+            host=host,
+            port=port,
+            rest_port=rest_port,
+        )
+        if self._transport is None:
+            logging.error(
+                "DSPVolume: no working transport to sigmatcpserver; "
+                "volume control via the DSP will be a no-op. Check that "
+                "sigmatcpserver is running and exposes either TCP (:8086) "
+                "or the REST API (:13141, --enable-rest).")
 
     # -- Public interface (matches ALSAVolume) --------------------------------
 
     def set_volume(self, vol):
-        # Track the last non-zero volume so unmute can restore it later.
         if vol == 0 and self.volume != 0:
             self.unmuted_volume = self.volume
 
         if vol == self.volume:
             return
 
+        if self._transport is None:
+            return
+
         amp = percent_to_amplification(vol, self.dbrange)
         try:
-            self._write_register(amp)
+            self._transport.write(amp)
         except Exception as e:
             logging.error("DSPVolume: failed to set volume to %s%%: %s",
                           vol, e)
@@ -182,7 +265,6 @@ class DSPVolume(threading.Thread):
             newvol = 0
         elif newvol > 100:
             newvol = 100
-
         self.set_volume(newvol)
 
     def set_mute(self, mute):
@@ -225,8 +307,11 @@ class DSPVolume(threading.Thread):
                                   e, listener)
 
     def current_volume(self):
+        if self._transport is None:
+            return self.volume if self.volume >= 0 else 0
+
         try:
-            amp = self._read_register()
+            amp = self._transport.read()
         except Exception as e:
             logging.debug("DSPVolume: read failed: %s", e)
             return self.volume if self.volume >= 0 else 0

--- a/audiocontrol2.conf.default
+++ b/audiocontrol2.conf.default
@@ -29,14 +29,18 @@ ShairportSync=shairport-sync
 # and Beocreate cards, see issue #43.
 #
 # control=dsp writes the HiFiBerry DSP volume register through
-# sigmatcpserver (start it with --enable-rest). This affects every source
-# that passes through the DSP, including optical.
+# sigmatcpserver. Uses SigmaTCP (port 8086) by default, which is available on
+# every HiFiBerryOS install. Falls back to REST (port 13141) when
+# sigmatcpserver runs with --enable-rest. Affects every source that passes
+# through the DSP, including optical.
 control=alsa
 mixer_control=Master
 
 # Only used when control=dsp:
+#transport=auto        # auto | sigmatcp | rest
 #dsp_host=localhost
-#dsp_port=13141
+#dsp_port=8086         # SigmaTCP
+#dsp_rest_port=13141   # REST fallback
 #dbrange=60
 
 [metadata_post]

--- a/audiocontrol2.conf.default
+++ b/audiocontrol2.conf.default
@@ -23,7 +23,21 @@ lms=lmsmpris
 ShairportSync=shairport-sync
 
 [volume]
+# control=alsa (default) drives the ALSA software mixer. Works for every
+# source that flows through ALSA (AirPlay, Spotify, MPD, ...). It does NOT
+# affect sources that bypass ALSA - notably the optical input on DAC+ DSP
+# and Beocreate cards, see issue #43.
+#
+# control=dsp writes the HiFiBerry DSP volume register through
+# sigmatcpserver (start it with --enable-rest). This affects every source
+# that passes through the DSP, including optical.
+control=alsa
 mixer_control=Master
+
+# Only used when control=dsp:
+#dsp_host=localhost
+#dsp_port=13141
+#dbrange=60
 
 [metadata_post]
 url=http://127.0.0.1:80/sources/metadata

--- a/doc/volume.md
+++ b/doc/volume.md
@@ -17,22 +17,42 @@ mixer_control=Master
 
 ## `control=dsp`
 
-Writes the HiFiBerry DSP `volumeControlRegister` through the REST API exposed
-by `sigmatcpserver`. This controls every source that passes through the DSP,
-including sources that bypass ALSA entirely - most notably the **optical
-(S/PDIF) input** on DAC+ DSP and Beocreate cards.
+Writes the HiFiBerry DSP `volumeControlRegister` through `sigmatcpserver`.
+This controls every source that passes through the DSP, including sources
+that bypass ALSA entirely - most notably the **optical (S/PDIF) input** on
+DAC+ DSP and Beocreate cards.
 
 Before the DSP backend existed, setting the volume via `/api/volume` while the
 optical input was active only moved the GUI slider; the audible volume did not
-change because the ALSA `Master` mixer is not in the optical signal path. See
-[issue #43](https://github.com/hifiberry/audiocontrol2/issues/43).
+change because the ALSA `Master` / `Softvol` mixer is not in the optical
+signal path. See [issue #43](https://github.com/hifiberry/audiocontrol2/issues/43).
+
+### Transports
+
+The DSP backend talks to `sigmatcpserver` through one of two transports. It
+picks whichever works at startup; you can force a specific one with the
+`transport` option.
+
+| `transport` value | What it does                                                |
+|-------------------|-------------------------------------------------------------|
+| `auto` (default)  | Try SigmaTCP first, fall back to REST.                      |
+| `sigmatcp`        | Use SigmaTCP only. Works on every stock HiFiBerryOS image.  |
+| `rest`            | Use REST only. Requires `sigmatcpserver --enable-rest`.     |
+
+SigmaTCP (TCP port 8086) is preferred because it is the default wire protocol
+on HiFiBerryOS and needs no `sigmatcpserver` configuration change. The
+backend uses the `SigmaTCPClient` class from the `hifiberrydsp` package that
+ships with HiFiBerryOS.
 
 ### Requirements
 
 - A HiFiBerry board with a DSP (e.g. DAC+ DSP, Beocreate).
-- `sigmatcpserver` running with `--enable-rest` (default on current
-  HiFiBerryOS images).
-- A loaded DSP profile that exposes a `volumeControlRegister` metadata entry.
+- `sigmatcpserver` running (default on HiFiBerryOS).
+- A loaded DSP profile that exposes a `volumeControlRegister` metadata entry
+  (every stock HiFiBerry profile does).
+- For `transport=sigmatcp` or `auto`: the `hifiberrydsp` Python package
+  (pre-installed on HiFiBerryOS).
+- For `transport=rest`: `sigmatcpserver` started with `--enable-rest`.
 
 ### Configuration
 
@@ -40,10 +60,36 @@ change because the ALSA `Master` mixer is not in the optical signal path. See
 [volume]
 control=dsp
 # Optional - defaults shown:
+#transport=auto
 #dsp_host=localhost
-#dsp_port=13141
+#dsp_port=8086         # SigmaTCP
+#dsp_rest_port=13141   # REST fallback
 #dbrange=60
 ```
 
 `dbrange` controls the log curve used to map 0 - 100 % to the DSP
-amplification factor. 60 dB matches `dsptoolkit`'s default.
+amplification factor. 60 dB matches `dsptoolkit`'s default and keeps the
+slider feel consistent with other HiFiBerry tools.
+
+### Verifying the DSP backend
+
+After restarting `audiocontrol2`, the log should contain lines like:
+
+```
+INFO: dspvolume - DSPVolume: using SigmaTCP reg=0x3d
+INFO: audiocontrol2 - using DSP volume control at localhost (transport=auto)
+```
+
+You can then confirm the DSP register actually moves when you hit the API:
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+     -d '{"percent":"30"}' http://<device>:81/api/volume
+dsptoolkit get-volume
+# -> Volume: 0.0079 / 30% / -42db
+
+curl -X POST -H 'Content-Type: application/json' \
+     -d '{"percent":"70"}' http://<device>:81/api/volume
+dsptoolkit get-volume
+# -> Volume: 0.1259 / 70% / -18db
+```

--- a/doc/volume.md
+++ b/doc/volume.md
@@ -1,0 +1,49 @@
+# Volume control
+
+`audiocontrol2` supports two volume backends, selected via the `control` option
+of the `[volume]` section in `/etc/audiocontrol2.conf`.
+
+## `control=alsa` (default)
+
+Uses `alsaaudio.Mixer(mixer_control)` to get and set a single ALSA mixer.
+This works well for sources that flow through ALSA (AirPlay via shairport-sync,
+Spotify via spotifyd, MPD, etc).
+
+```ini
+[volume]
+control=alsa
+mixer_control=Master
+```
+
+## `control=dsp`
+
+Writes the HiFiBerry DSP `volumeControlRegister` through the REST API exposed
+by `sigmatcpserver`. This controls every source that passes through the DSP,
+including sources that bypass ALSA entirely - most notably the **optical
+(S/PDIF) input** on DAC+ DSP and Beocreate cards.
+
+Before the DSP backend existed, setting the volume via `/api/volume` while the
+optical input was active only moved the GUI slider; the audible volume did not
+change because the ALSA `Master` mixer is not in the optical signal path. See
+[issue #43](https://github.com/hifiberry/audiocontrol2/issues/43).
+
+### Requirements
+
+- A HiFiBerry board with a DSP (e.g. DAC+ DSP, Beocreate).
+- `sigmatcpserver` running with `--enable-rest` (default on current
+  HiFiBerryOS images).
+- A loaded DSP profile that exposes a `volumeControlRegister` metadata entry.
+
+### Configuration
+
+```ini
+[volume]
+control=dsp
+# Optional - defaults shown:
+#dsp_host=localhost
+#dsp_port=13141
+#dbrange=60
+```
+
+`dbrange` controls the log curve used to map 0 - 100 % to the DSP
+amplification factor. 60 dB matches `dsptoolkit`'s default.


### PR DESCRIPTION
## Context

Closes #43.

On HiFiBerry **DAC+ DSP** / **Beocreate** and similar DSP cards, audio from the
optical (S/PDIF) input is processed by the DSP hardware and never flows through
the ALSA software mixer. As a result, `POST /api/volume` only moved the GUI
slider while the audible volume was unchanged whenever optical was the active
source. The slider follows the ALSA `Master` level (which is what `audiocontrol2`
writes), so the UI looks correct, but the optical signal path bypasses that
mixer entirely.

AirPlay, Spotify, MPD and friends work today because those streams flow through
ALSA before they reach the DSP.

## Change

Adds a second volume backend, `DSPVolume`, which writes the DSP's
`volumeControlRegister` via the `sigmatcpserver` REST API (port 13141 by
default). That register sits inside the DSP signal path, so it affects every
source - including optical.

The backend is selected through a new `control` option in `[volume]`:

```ini
# ALSA (existing behaviour, default, unchanged for every current install)
[volume]
control=alsa
mixer_control=Master

# DSP (new, required for optical on DAC+ DSP / Beocreate)
[volume]
control=dsp
# dsp_host=localhost
# dsp_port=13141
# dbrange=60
```

`DSPVolume` exposes the same interface as `ALSAVolume` (`set_volume`,
`current_volume`, `set_mute`, `toggle_mute`, `change_volume_percent`, listener
registration, polling thread), so nothing else in `audiocontrol2` has to change.
It resolves the register address from `/metadata` once at startup and uses
`/memory` for the read/write calls documented in `hifiberry-dsp`'s
[restapi.md](https://github.com/hifiberry/hifiberry-dsp/blob/master/doc/restapi.md).

The percent <-> amplification conversion copies the log curve used by
`dsptoolkit` (`hifiberrydsp.filtering.volume`) so the slider feels consistent
with other HiFiBerry tools. I inlined the coefficients rather than adding a
dependency on the `hifiberrydsp` package.

## Files

- `ac2/dspvolume.py` - new backend.
- `ac2/audiocontrol2.py` - route to `DSPVolume` when `control=dsp`, keep ALSA as
  default so existing installs are untouched.
- `audiocontrol2.conf.default` - document both backends.
- `doc/volume.md` - explain when to use each.

## Requirements for the DSP backend

- A HiFiBerry board with a DSP (e.g. DAC+ DSP, Beocreate).
- `sigmatcpserver --enable-rest` (default on current HiFiBerryOS images).
- A loaded DSP profile that exposes `volumeControlRegister` metadata.

## Verification

- Round-trip tested `percent_to_amplification` / `amplification_to_percent` at
  every 10 % step - all map back cleanly.
- Syntax-checked both changed Python files.
- Default config behaviour is unchanged; new behaviour is strictly opt-in via
  `control=dsp`.

Happy to iterate on naming (`control` vs `backend`, `dsp_host` vs `host`, etc.)
or to split the config into a separate section like `[volume_dsp]` if you'd
prefer that shape.