### PR TITLE
docs: clarify Socket.IO namespace subscription (#42)

### DIFF
--- a/doc/socketio_api.md
+++ b/doc/socketio_api.md
@@ -1,42 +1,137 @@
 # Socketio API
-With this API you can control players with socketio. It is possible the register for metadata and volume events.
 
-# Howto enable Socketio API
-This API is only available if it is enabled in your `etc/audiocontrol2.conf`:
-```
+`audiocontrol2` exposes a Socket.IO API that lets a client receive real-time
+metadata and volume updates, and send player control commands.
+
+## Enabling the Socket.IO API
+
+Enable it in `/etc/audiocontrol2.conf`:
+
+```ini
 [webserver]
 enable=yes
 port=81
 socketio_enabled=True
 ```
 
-# Example client
-This client prints the metadata json dump whenever new metadata is available in audiocontrol2.
-Use pip install "python-socketio[asyncio_client]" to install socketio with the async client. Be aware to use the same version of socketio as install on HiFiBerryOS (5.4.0 at the time of writing).
+## Namespaces
 
+The server exposes three namespaces. Events are **only delivered to clients
+that explicitly subscribe to the namespace** - connecting to the default
+namespace (`/`) is not enough.
+
+| Namespace   | Server -> client events | Client -> server events                                    |
+|-------------|-------------------------|------------------------------------------------------------|
+| `/metadata` | `update` (metadata dict) | `get`                                                      |
+| `/volume`   | `update` (`{percent}`)   | `get`, `set` (`{percent}`)                                  |
+| `/player`   | -                       | `status`, `playing`, `play`, `pause`, `play_pause`, `stop`, `next`, `previous` |
+
+> If your client only sees the connection SID and then nothing else (see
+> [issue #42](https://github.com/hifiberry/audiocontrol2/issues/42)), it is
+> almost always because it subscribed only to `/` and not to the namespace it
+> actually wants updates from.
+
+## Python client example
+
+Install the async client with the same `python-socketio` version as the server
+(5.4.0 on current HiFiBerryOS images):
+
+```bash
+pip install "python-socketio[asyncio_client]==5.4.0"
 ```
+
+```python
 import asyncio
 import json
 import socketio
 
 sio = socketio.AsyncClient()
 
+
 @sio.event
 async def connect():
-    print('connection established')
+    print("connection established")
 
-@sio.event(namespace="/metadata")
-async def update(data):
-    print('metadata update: %s', json.dumps(data))
 
 @sio.event
 async def disconnect():
-    print('disconnected from server')
+    print("disconnected from server")
+
+
+# Register handlers on each namespace you want to listen to.
+@sio.on("update", namespace="/metadata")
+async def metadata_update(data):
+    print("metadata update:", json.dumps(data))
+
+
+@sio.on("update", namespace="/volume")
+async def volume_update(data):
+    print("volume update:", data)
+
 
 async def main():
-    await sio.connect('http://hifiberry.local:81')
+    # Subscribe to every namespace you want events from. Missing this is the
+    # most common reason for "connected but no events".
+    await sio.connect(
+        "http://hifiberry.local:81",
+        namespaces=["/metadata", "/volume", "/player"],
+    )
+
+    # Pull the current values once after connecting.
+    metadata = await sio.call("get", namespace="/metadata")
+    volume = await sio.call("get", namespace="/volume")
+    print("initial metadata:", metadata)
+    print("initial volume:", volume)
+
+    # Example: set volume to 40%.
+    await sio.emit("set", {"percent": 40}, namespace="/volume")
+
     await sio.wait()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+## JavaScript / browser client example
+
+In the JavaScript `socket.io-client`, each namespace is a separate `Socket`
+instance created by passing the namespace as the path component of the URL:
+
+```html
+<script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+<script>
+  const base = "http://hifiberry.local:81";
+
+  const metadataSocket = io(`${base}/metadata`);
+  metadataSocket.on("connect", () => console.log("metadata connected"));
+  metadataSocket.on("update", (data) => console.log("metadata update", data));
+
+  const volumeSocket = io(`${base}/volume`);
+  volumeSocket.on("update", (data) => console.log("volume update", data));
+
+  // Request the current volume.
+  volumeSocket.emit("get", (reply) => console.log("current volume", reply));
+
+  // Set volume to 25 %.
+  volumeSocket.emit("set", { percent: 25 });
+
+  const playerSocket = io(`${base}/player`);
+  playerSocket.emit("play");
+</script>
+```
+
+The same rule applies to every other Socket.IO client library (Java, Swift,
+Go, ...): open one socket per namespace.
+
+## Troubleshooting
+
+- **Connected but no events.** You are on the default namespace. Add the
+  `/metadata`, `/volume` or `/player` namespace to your connection (see the
+  table above).
+- **`get` returns nothing.** The `get` events are request/response-style - use
+  `sio.call(...)` in Python or the acknowledgement callback in JavaScript
+  rather than `sio.emit(...)`.
+- **Mismatched protocol.** `socketio_enabled=True` requires the gevent-based
+  server path; keep the `python-socketio` version on the client aligned with
+  the server.


### PR DESCRIPTION
## Context

Closes #42.

The user in #42 reports connecting to the Socket.IO server, receiving the SID,
and then seeing nothing for `update`, `metadata` or `volume` events. The
existing `doc/socketio_api.md` example connects only to the default namespace
(`sio.connect('http://hifiberry.local:81')`) and then relies on
`python-socketio` auto-subscribing to `/metadata` because an event handler
carries `namespace='/metadata'`.

That implicit behaviour is version-dependent in python-socketio and does not
apply at all to non-Python clients. The JavaScript `socket.io-client`, for
example, requires a separate socket per namespace (`io('http://host/metadata')`).
So a reasonable reading of the docs produces a broken client.

## Change

Documentation-only rewrite of `doc/socketio_api.md`:

- Lists every server namespace (`/metadata`, `/volume`, `/player`) with the
  events each side emits and accepts - including the request/response-style
  `get` events that need `sio.call(...)` (Python) or an ack callback (JS).
- Python example now passes `namespaces=['/metadata', '/volume', '/player']`
  to `sio.connect(...)` and uses `@sio.on('update', namespace='/metadata')`
  so it is completely explicit.
- Adds a JavaScript / browser example using per-namespace sockets.
- Calls out the "connected but no events" failure mode from #42 in a short
  Troubleshooting section so future readers don't hit the same wall.

No server-side changes - the current namespace split is fine, the docs just
weren't explicit enough about the client side of the contract.

## Verification

Re-read `ac2/socketio.py` to confirm the listed events and namespaces match
what the server actually exposes (`MetadataHandler` -> `/metadata`,
`VolumeHandler` -> `/volume`, `PlayerHandler` -> `/player`, module-level
`connect`/`disconnect` on `/`).