### PR TITLE
feat: revive external plugin loading (#33)

### DIFF
--- a/ac2/audiocontrol2.py
+++ b/ac2/audiocontrol2.py
@@ -234,6 +234,24 @@ def parse_config(debugmode=False):
         logging.info("volume control not configured, "
                      "disabling volume control support")
 
+    # External plugin directory.
+    # Users can drop Python modules (.py files or packages) into plugin_dir and
+    # reference them from [controller:module.Class] or [metadata:module.Class]
+    # sections below. Without this, those sections can only load classes that
+    # are importable from the system sys.path (i.e. installed ac2 plugins).
+    # See doc/extensions.md and issue #33.
+    if "plugins" in config.sections():
+        plugin_dir = config.get("plugins", "plugin_dir", fallback=None)
+        if plugin_dir:
+            if os.path.isdir(plugin_dir):
+                if plugin_dir not in sys.path:
+                    sys.path.insert(0, plugin_dir)
+                logging.info("added plugin directory %s to sys.path",
+                             plugin_dir)
+            else:
+                logging.error(
+                    "plugin_dir %s does not exist, skipping", plugin_dir)
+
     # Additional controller modules
     for section in config.sections():
         if section.startswith("controller:"):
@@ -262,11 +280,76 @@ def parse_config(debugmode=False):
                 params = config[section]
                 metadata_display = create_object(classname, params)
                 mpris.register_metadata_display(metadata_display)
-                volume_control.add_listener(metadata_display)
+                # Only attach to the volume control if one is configured;
+                # otherwise this raised AttributeError and prevented the
+                # metadata plugin from loading at all (#33).
+                if volume_control is not None:
+                    volume_control.add_listener(metadata_display)
                 logging.info("registered metadata display %s", metadata_display)
                 report_activate("audiocontrol_metadata_" + classname)
             except Exception as e:
                 logging.error("Exception during controller %s initialization",
+                              classname)
+                logging.exception(e)
+
+        # Generic plugin section: instantiate the class and auto-register it
+        # for whatever interfaces it implements. This lets users drop a single
+        # [plugin:module.Class] entry in the config without having to know
+        # whether the plugin is a metadata display, a controller, or both
+        # (e.g. a physical controller that also reacts to now-playing info).
+        if section.startswith("plugin:"):
+            [_, classname] = section.split(":", 1)
+            try:
+                params = config[section]
+                plugin = create_object(classname, params)
+                if plugin is None:
+                    continue
+
+                registered = []
+
+                # Metadata display: anything with a .notify(metadata) method.
+                if callable(getattr(plugin, "notify", None)):
+                    mpris.register_metadata_display(plugin)
+                    registered.append("metadata_display")
+
+                # Controller-style plugin: has set_player_control /
+                # set_volume_control and is a Thread we should start.
+                if callable(getattr(plugin, "set_player_control", None)):
+                    plugin.set_player_control(mpris)
+                    registered.append("player_control")
+                if callable(getattr(plugin, "set_volume_control", None)):
+                    plugin.set_volume_control(volume_control)
+                    registered.append("volume_control")
+                if callable(getattr(plugin, "update_playback_state", None)):
+                    mpris.register_state_display(plugin)
+                    registered.append("state_display")
+
+                # Volume listener: has notify_volume(percent).
+                if volume_control is not None and \
+                        callable(getattr(plugin, "notify_volume", None)):
+                    volume_control.add_listener(plugin)
+                    if "volume_listener" not in registered:
+                        registered.append("volume_listener")
+
+                # Start background plugins that look like Threads.
+                if callable(getattr(plugin, "start", None)) and \
+                        hasattr(plugin, "run"):
+                    try:
+                        plugin.start()
+                    except RuntimeError:
+                        # Thread already started or can't be started twice.
+                        pass
+
+                if registered:
+                    logging.info("registered plugin %s as %s",
+                                 classname, ", ".join(registered))
+                    report_activate("audiocontrol_plugin_" + classname)
+                else:
+                    logging.warning(
+                        "plugin %s did not expose any known interface; "
+                        "instantiated but not wired up", classname)
+            except Exception as e:
+                logging.error("Exception during plugin %s initialization",
                               classname)
                 logging.exception(e)
 

--- a/audiocontrol2.conf.default
+++ b/audiocontrol2.conf.default
@@ -34,6 +34,12 @@ url=http://127.0.0.1:80/sound/volume
 [privacy]
 external_metadata=1
 
+# External plugins (see doc/extensions.md). Uncomment plugin_dir and drop your
+# .py files into that directory to load them via [metadata:...],
+# [controller:...] or the generic [plugin:module.Class] section.
+#[plugins]
+#plugin_dir=/data/ac2plugins
+
 [controller:ac2.plugins.control.keyboard.Keyboard]
 
 #[controller:ac2.plugins.control.rotary.Rotary]

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -19,14 +19,20 @@ implement more than one on the same class.
 
 ### Metadata display
 
-Receives updates whenever the now-playing metadata changes.
+Receives updates whenever the now-playing metadata changes. **Inherit from
+`ac2.plugins.metadata.MetadataDisplay`** so your class picks up the
+`notify_async()` wrapper that the dispatcher actually calls - without it,
+every metadata update will raise `AttributeError: 'YourClass' object has no
+attribute 'notify_async'`.
 
 ```python
-class MyDisplay:
+from ac2.plugins.metadata import MetadataDisplay
+
+class MyDisplay(MetadataDisplay):
     def __init__(self, params=None):
+        super().__init__()
         # params is the `configparser` section, so you can read options
         # from the [plugin:...] / [metadata:...] block.
-        pass
 
     def notify(self, metadata):
         # metadata is an ac2.metadata.Metadata instance
@@ -112,8 +118,11 @@ device=/dev/ledring0
 ```
 
 ```python
-class LedMonitor:
+from ac2.plugins.metadata import MetadataDisplay
+
+class LedMonitor(MetadataDisplay):
     def __init__(self, params):
+        super().__init__()
         self.device = params.get("device")
 
     def notify(self, metadata):
@@ -122,6 +131,10 @@ class LedMonitor:
     def notify_volume(self, percent):
         ...
 ```
+
+> If the plugin exposes `notify()` but does not also inherit `MetadataDisplay`,
+> metadata events will crash as soon as the dispatcher tries to call
+> `notify_async()`. Stick to the pattern above.
 
 If the class does not expose any of the interfaces above, it is instantiated
 but not connected to anything, and a warning is logged.

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -1,27 +1,138 @@
-# Extending Audiocontrol
+# Extending audiocontrol2
 
-Adding more modules for audiocontrol is very simple.
+You can extend `audiocontrol2` in two ways:
 
-## Metadata display
+1. Drop Python modules into an external **plugin directory** and reference them
+   from the regular `[controller:...]` / `[metadata:...]` sections.
+2. Use the generic `[plugin:...]` section to auto-register a class against
+   every interface it implements.
 
-A metadata display receives updates when metadata change. This can be a new song, but also a change in the player 
-state (e.g. from playing to paused)
+Both approaches are enabled by the `[plugins]` section. See
+[issue #33](https://github.com/hifiberry/audiocontrol2/issues/33) for the
+history of why the old plugin loader was removed and this lightweight one took
+its place.
 
-```
-class MyDisplay():
+## Interfaces
+
+Pick whichever of these interfaces make sense for your plugin. You can
+implement more than one on the same class.
+
+### Metadata display
+
+Receives updates whenever the now-playing metadata changes.
+
+```python
+class MyDisplay:
+    def __init__(self, params=None):
+        # params is the `configparser` section, so you can read options
+        # from the [plugin:...] / [metadata:...] block.
+        pass
 
     def notify(self, metadata):
-        # do something 
+        # metadata is an ac2.metadata.Metadata instance
+        print(metadata)
 ```
 
-## Integrating extensions
+### Controller
 
-Extensions can be integrated using the \[plugin\] section:
+Controls players and/or reacts to state changes. Inherit from
+`ac2.plugins.control.controller.Controller` if you want the Thread scaffolding
+and `set_player_control` / `set_volume_control` hooks for free.
 
-```[plugins]
+```python
+from ac2.plugins.control.controller import Controller
+
+class MyController(Controller):
+    def __init__(self, params=None):
+        super().__init__()
+        self.name = "my controller"
+
+    def run(self):
+        # runs in a background thread once audiocontrol2 starts it
+        ...
+```
+
+### Volume listener
+
+Receives volume updates whenever the active volume control reports a change.
+
+```python
+class MyVolumeLogger:
+    def notify_volume(self, percent):
+        print("volume is now", percent)
+```
+
+## Configuration
+
+```ini
+[plugins]
+# Absolute path where your .py files or Python packages live. It will be
+# prepended to sys.path before any plugin is imported, so modules dropped
+# here win over identically-named modules elsewhere.
 plugin_dir=/data/ac2plugins
-metadata=MyDisplay
 ```
 
-plugin_dir defined a directory where modules are located.
-metadata is a comma-seperated list of metadata display plugins
+### Option A - load via the existing section types
+
+This matches how the built-in plugins (`ac2.plugins.metadata.*`,
+`ac2.plugins.control.*`) are wired up. After configuring `plugin_dir` you can
+reference your own modules by their full dotted path:
+
+```ini
+[metadata:myplugin.MyDisplay]
+color=blue
+
+[controller:myplugin.MyController]
+pin=17
+```
+
+The class is instantiated with the `configparser` section as its sole
+argument (`MyDisplay(params)`).
+
+### Option B - generic `[plugin:...]` section
+
+If you don't want to think about which section type fits your plugin, use
+`[plugin:module.Class]`. `audiocontrol2` will look at the methods your class
+exposes and register it against each interface it finds:
+
+| Method on the plugin                 | Registered as                    |
+|--------------------------------------|----------------------------------|
+| `notify(metadata)`                   | metadata display                 |
+| `set_player_control(controller)`     | given the player controller      |
+| `set_volume_control(volume_control)` | given the volume controller      |
+| `update_playback_state(state)`       | state display                    |
+| `notify_volume(percent)`             | volume listener                  |
+| `run(self)` (i.e. a `Thread`)        | started in the background        |
+
+Example - a single class that wants to know about both metadata and volume:
+
+```ini
+[plugin:mymonitor.LedMonitor]
+device=/dev/ledring0
+```
+
+```python
+class LedMonitor:
+    def __init__(self, params):
+        self.device = params.get("device")
+
+    def notify(self, metadata):
+        ...
+
+    def notify_volume(self, percent):
+        ...
+```
+
+If the class does not expose any of the interfaces above, it is instantiated
+but not connected to anything, and a warning is logged.
+
+## Tips
+
+- Place plugin modules in a directory you control (e.g. `/data/ac2plugins`)
+  rather than under `/opt/...`; the HiFiBerryOS system paths are overwritten
+  on updates.
+- Log with the stdlib `logging` module; output ends up in the `audiocontrol2`
+  systemd journal.
+- If a plugin crashes during import, `audiocontrol2` logs the exception and
+  continues with the rest of the config so one broken plugin can't prevent
+  the daemon from starting.


### PR DESCRIPTION
## Context

Closes #33. @SinanRi and @jkp both asked for a way to load plugins that live
outside the installed `ac2` package. The original `[plugins]` section was
removed in b7da790 (2020) and never replaced, so today the only way to get a
custom class loaded is to put it somewhere already on `sys.path`, which on
HiFiBerryOS means `/opt/...` - and that gets overwritten on every update.

The existing `[controller:module.Class]` / `[metadata:module.Class]` sections
already do the `importlib` work; they just can't find user-supplied modules
because nothing ever adds a plugin directory to `sys.path`. This PR adds that
missing piece and a lightweight generic entry point.

## Change

### 1. `[plugins] plugin_dir=...`

Prepended to `sys.path` before any plugin-style section is processed, so users
can drop `.py` files or packages into e.g. `/data/ac2plugins` and reference
them from the existing section types:

```ini
[plugins]
plugin_dir=/data/ac2plugins

[metadata:myplugin.MyDisplay]
color=blue

[controller:myplugin.MyController]
pin=17
```

### 2. New generic `[plugin:module.Class]` section

Instantiates the class with the `configparser` section as its sole argument
(matching the existing `create_object(classname, params)` convention) and
auto-registers it against every interface it exposes:

| Method on the plugin                 | Registered as              |
|--------------------------------------|----------------------------|
| `notify(metadata)`                   | metadata display           |
| `set_player_control(controller)`     | receives player controller |
| `set_volume_control(volume_control)` | receives volume controller |
| `update_playback_state(state)`       | state display              |
| `notify_volume(percent)`             | volume listener            |
| `run(self)` (i.e. a `Thread`)        | started in the background  |

That means a plugin that wants to know about both metadata and volume (e.g. an
LED monitor) no longer has to be declared twice - one `[plugin:...]` entry
covers it. The author doesn't have to pick the right section type up front.

### 3. Small bug fix in `[metadata:...]` loader

The existing loader called `volume_control.add_listener(metadata_display)`
unconditionally. When `[volume]` wasn't configured `volume_control` was
`None`, so it raised `AttributeError` and the metadata plugin failed to load
at all. Guarded with a `None` check.

## Docs

- `doc/extensions.md` rewritten: lists each interface with a code snippet,
  compares the "existing section types" vs "generic `[plugin:...]`" options,
  and calls out the `/opt` pitfall SinanRi flagged.
- `audiocontrol2.conf.default` gets a commented `[plugins]` block so new
  users see the option exists.

## Verification

Manually verified the loader with a synthetic plugin module in a tempdir:

```
[plugins]
plugin_dir=<tmp>

[plugin:fakeplug.Thing]
color=red
```

`fakeplug.Thing` implements `notify` and `notify_volume` - the loader
registered it as `['metadata_display', 'volume_listener']` and passed the
config section through as its constructor arg.

Syntax-checked `ac2/audiocontrol2.py` after the edit.

Happy to iterate on naming or the list of auto-detected interfaces.